### PR TITLE
Bug Fix: #20 - Add Video Codec function counts off

### DIFF
--- a/VideoCodecRename_1.2.py
+++ b/VideoCodecRename_1.2.py
@@ -13,7 +13,7 @@ Release Notes: 1.2
 - Added file counts to all operations
 - Standardized all output formatting for all operations.
 - Set each operation to reset variable TotalCount after it ran to ensure accurate counts between operations.
-- 
+- Replaced <path = "/home/dustin/Videos"> with <path = "/home/dustin/Videos">
 
 '''
 import tkinter as tk
@@ -43,7 +43,7 @@ path_entry = tk.Label(text='Working Directory')
 path_entry.pack()
 path_entry = tk.Entry(width=100)
 path_entry.pack()
-path = path_entry.get()
+path = "/home/dustin/Videos"
 #----------------------------------------------------------
 # List Button
 
@@ -126,11 +126,12 @@ def clear_screen_pressed(event):
 button_clear_screen.bind('<Button-1>', clear_screen_pressed)
 #----------------------------------------------------------
 def add_pressed(event):
-    path = path_entry.get()
+    path = "/home/dustin/Videos"
     
     TotalCount = 0
+    VideoCount = 0
 
-    VideoExtensions = ['.mov', '.MOV', '.MP4', '.mp4', '.MKV', '.mkv', '.AVI', '.avi', '.M4V', '.m4v', '.MPG',  '.mpg']
+    VideoExtensions = ['.mov', '.mp4', '.mkv', '.avi', '.m4v', '.mpg']
     VideoCodecs = ['utvideo', 'dnxhd', 'h265', 'h264', 'xvid', 'mpeg4', 'msmpeg4v3', 'error']
     VideoCodecCounts = {'utvideo': 0, 'dnxhd': 0, 'h265': 0, 'h264': 0, 'xvid': 0, 'mpeg4': 0, 'msmpeg4v3': 0, 'error': 0}
     files = []
@@ -145,35 +146,40 @@ def add_pressed(event):
         try:
             for r, d, f in sorted(os.walk(path, topdown=True)):
                 for file in f:
+                    TotalCount += 1
                     Extension = os.path.splitext(file)[1] # Returns a tuple, with the extension at index 1
                     if '[' not in file:
                         for ex in VideoExtensions:
                             if ex in file.lower():
-                                current = os.path.join(r, file)
-                                TotalCount += 1
+                                current = os.path.join(r, file)                                
                                 metadata = FFProbe(str(current))
                                 for stream in metadata.streams:
                                     codec = stream.codec()
                                     if stream.codec() in VideoCodecs:
+                                        VideoCount += 1
                                         VideoCodecCounts[codec] += 1
                                         newName = f'{current[0:-len(Extension)]}[{codec}]{Extension}'
                                         rename(current, newName)
                                         output_box.insert('1.0', 'New name: ' + newName)
                                         output_box.insert(1.0, '\n')
         except:
+            TotalCount += 1
             VideoCodecCounts['error'] += 1
-            output_box.insert("1.0", "**ERROR: " + str(current))
-            output_box.insert(1.0, "\n")
             rename(current, current[0:-4] + '[ERROR]' + current[-4:])
-            output_box.insert("1.0", '**Offending File Marked')
+            
+            output_box.insert('1.0', 'New name: ' + newName)
             output_box.insert(1.0, "\n")
+
             pass
         else:
+            TotalCount = VideoCount + VideoCodecCounts['error']
             output_box.insert(1.0, '\n')
             output_box.insert('1.0', '-' * 20)
             output_box.insert(1.0, '\n')
             output_box.insert('1.0', 'Files Renamed: ' + str(TotalCount))
             output_box.insert(1.0, '\n')
+            output_box.insert(1.0, "Errors Ecountered: " + str(VideoCodecCounts['error']))
+            output_box.insert(1.0, "\n")
             output_box.insert('1.0', 'Video Rename Operation Completed: ' + str(datetime.datetime.now()))
             output_box.insert(1.0, '\n')
             output_box.insert('1.0', '-' * 20)
@@ -199,7 +205,7 @@ def add_pressed(event):
 button_add.bind('<Button-1>', add_pressed)
 #----------------------------------------------------------
 def find_videos_pressed(event):
-    path = path_entry.get()
+    path = "/home/dustin/Videos"
     
     TotalCount = 0
     VideoFileCount = 0
@@ -228,8 +234,7 @@ def find_videos_pressed(event):
             output_box.insert("1.0", "**ERROR: " + str(current))
             output_box.insert(1.0, "\n")
             rename(current, current[0:-4] + '[ERROR]' + current[-4:])
-            output_box.insert("1.0", '**Offending File Marked')
-            output_box.insert(1.0, "\n")
+            
             pass
         else:
             output_box.insert(1.0, '\n')
@@ -246,7 +251,7 @@ button_list_videos.bind('<Button-1>', find_videos_pressed)
 #----------------------------------------------------------
 #----------------------------------------------------------
 def list_all_pressed(event):
-    path = path_entry.get()
+    path = "/home/dustin/Videos"
     TotalCount = 0
     
     while True:
@@ -277,7 +282,7 @@ def list_all_pressed(event):
 button_list_all.bind('<Button-1>', list_all_pressed)
 #----------------------------------------------------------
 def remove_pressed(event):
-    path = path_entry.get()
+    path = "/home/dustin/Videos"
     output_box.insert('1.0', 'Remove Operation Started: ' + str(datetime.datetime.now()))
     output_box.insert(1.0, '\n')
     output_box.insert('1.0', '-' * 20)
@@ -319,6 +324,7 @@ button_remove.bind('<Button-1>', remove_pressed)
 #----------------------------------------------------------
 
 window.mainloop()
+
 
 
 


### PR DESCRIPTION
VideoCodecRename Issue #20: Counts are off for Add Codec function

Working directory: path = "/home/dustin/Videos/TEST"
Total files(verified): 109
Total files found: 111
Videos found: 80
Total files renamed(claimed by code): 360

I suspect that it's counting every single file in the directory as a video file with an error. I also suspect it's somehow counting files multiple times. There are 360 files it seems to find, but only 80 video files, which means that only 80 files should be renamed, aside from the ones with the ".mp4.pfl" extensions, as those are not videos. Known issue to be dealt with later.

The following code seems to be at fault:
        except:
            VideoCodecCounts['error'] += 1
            output_box.insert("1.0", "**ERROR: " + str(current))
            output_box.insert(1.0, "\n")
                rename(current, current[0:-4] + '[ERROR]' + current[-4:])
                output_box.insert("1.0", '**Offending File Marked')
                output_box.insert(1.0, "\n")
                pass

That is the "except" for the add_pressed function, and it does not descriminate based on file type.

New code to test:
except:
            VideoCodecCounts['error'] += 1
            output_box.insert("1.0", "**ERROR: " + str(current))
            output_box.insert(1.0, "\n")
            for ex in VideoExtensions:
                if ex in file.lower():
                    rename(current, current[0:-4] + '[ERROR]' + current[-4:])
                    output_box.insert("1.0", '**Offending File Marked')
                    output_box.insert(1.0, "\n")
                    pass

That resulted in 40 files being renamed, on top of the ones that were renamed in the last operation. Removing extensions and testing again. Test reported 360 files renamed, same as initial. Removing the lines that add "**Offending File Marked" to the output as it adds another line, breaks up the output in an unpleasant way, and makes counting lines much more difficult.

Removed the following:
    output_box.insert("1.0", '**Offending File Marked')
            output_box.insert(1.0, "\n")

Running the test again. 40 files were reported renamed. 40 files were actually renamed during this operation. Trying to figure out why. Suspect directory has something to do with it. Finding a file that was not renamed, comparing it's directory to that of one that was successsfully renamed.
/home/dustin/Videos/TEST/TEST_VIDEO_001[utvideo].mkv was properly renamed.
I found that all video files were properly located and renamed. There are 40 in total. I can verify that the rename function does work, but the counts are off. Looking back over the code that identifies the videos in the first place.
Realized that the VideoExtensions dictionary still had the old capitalized versions, removed and updated: VideoExtensions = ['.mov', '.mp4', '.mkv', '.avi', '.m4v', '.mpg']
The counts for the Find Videos function are also wrong. It's actually off by 40. Reports 80, when there are only 40 actual video files. I suspect this is due to the bug that reports the ",mp4.pfl" files as videos. A search of the output for Find Videos returns 40 matches for the term "pfl". 40 of the 80 files returned were a product of bug #19. Fixing that will fix this incoreect count. This still doesn't explain why the add_pressed function returns a count of 360 files.

Testing to see what happens with only a .pfl extension: 
Ignores the file in all operations.
Testing with a .mp4.pfl extension:
Marks the file as a video.

The following line is what defines the extensions for this function:
Extension = os.path.splitext(file)[1] # Returns a tuple, with the extension at index 1

I don't fully understand this code, as it was recommended to me by someone else. It works, does not account for things that have an extension added after the original extension. Trying to determine the best way to have it only check until for extensions up until the period closest to the end of the file name.

Another way to do this is to remove the "[error]" aspect entirely and just have it leave all unknown files alone. This would solve issue #21 It would slow down search significantly as it would try to open every single file with ffmpeg, but it would find all videos of the types specified.
Testing the run time of this program before and after this change:
Time to rename before change: 1:28 
Time to rename after change: 7:55

Old code:
    while True:
        try:
            for r, d, f in sorted(os.walk(path, topdown=True)):
                for file in f:
                    Extension = os.path.splitext(file)[1] # Returns a tuple, with the extension at index 1
                    if '[' not in file:
                        for ex in VideoExtensions:
                            if ex in file.lower():
                                current = os.path.join(r, file)
                                TotalCount += 1
                                metadata = FFProbe(str(current))
                                for stream in metadata.streams:
                                    codec = stream.codec()
                                    if stream.codec() in VideoCodecs:
                                        VideoCodecCounts[codec] += 1
                                        newName = f'{current[0:-len(Extension)]}[{codec}]{Extension}'
                                        rename(current, newName)
                                        output_box.insert('1.0', 'New name: ' + newName)
                                        output_box.insert(1.0, '\n')


New Code:
    while True:
        try:
            for r, d, f in sorted(os.walk(path, topdown=True)):
                for file in f:
                    #Extension = os.path.splitext(file)[1] # Returns a tuple, with the extension at index 1
                    if '[' not in file:
                        #for ex in VideoExtensions:
                            #if ex in file.lower():
                                current = os.path.join(r, file)
                                TotalCount += 1
                                metadata = FFProbe(str(current))
                                for stream in metadata.streams:
                                    codec = stream.codec()
                                    if stream.codec() in VideoCodecs:
                                        VideoCodecCounts[codec] += 1
                                        newName = f'{current[0:-len(Extension)]}[{codec}]{Extension}'
                                        rename(current, newName)
                                        output_box.insert('1.0', 'New name: ' + newName)
                                        output_box.insert(1.0, '\n')

This took significantly longer and marked every single video file as "[ERROR]". It counted 2,694 files. Moved the line that counts the files down to the following location to stop counting all files and only count if a file has been determined to be a video.
    if stream.codec() in VideoCodecs:
        TotalCount += 1

Not sure why the following code ended up in the add_pressed function, but it seems to be the problem. It would come in after the main rename operation and nream everything t [error]. Removing and testing again.

        except:
            VideoCodecCounts['error'] += 1
            output_box.insert("1.0", "**ERROR: " + str(current))
            output_box.insert(1.0, "\n")
            for ex in VideoExtensions:
                if ex in file.lower():
                    rename(current, current[0:-4] + '[ERROR]' + current[-4:])
                    pass

Suspected problem code:
for ex in VideoExtensions:
                if ex in file.lower():
                    rename(current, current[0:-4] + '[ERROR]' + current[-4:])
Run time after change: Unknown
The program seemed to be stuck in a loop. Changed the directory to the TEST directory with only 4 files in it. Still apears to be hanging up.
Opened a blank python file, removed all the error ignoring code, got the follwoing error:
  File "/home/dustin/Documents/Projects/CodecRenameUtility/JUNK2.py", line 158, in add_pressed
    newName = f'{current[0:-len(Extension)]}[{codec}]{Extension}'
NameError: name 'Extension' is not defined

Uncommented the following line to get it working again:
Extension = os.path.splitext(file)[1] # Returns a tuple, with the extension at index 1
Adjusted the output to show the total files scanned and the video files renamed.
Tried to have it print out the name of every file as it was scanning, but it doesn't work. I suspect the while loop is to blame. Reverting changes, moving on for now.
Program is hanging up after 8 files every time.
Latest changes having the code working. It found and renamed 33 video files. All 40 video files have been properly renamed. The operation took about 1 minute. 

I figured out why the program was hanging up. I removed the line that adds "[ERROR]" to the name. As the add_pressed function checks for [ in the name, this caused it to loop infinitely. Without that "[" in the file name that throws an error, the program gets to it, passes it up, then starts the search from the top, coming to the same file again. Marking the file lets it finish running. This looping back would also explain why the total file count is off. It's hitting an error condition, then starting the scan over again, counting files multiple times until it has gotten all the way through. Removing the total count for now, implementing as a separate function to get an accurate total count.
The renamed count is still off, but that's likely because the [error] videos aren't included in that count. 

Adding to the except section:
TotalCount += 1

This had no effect on the total count. Not sure why.
It seems things are getting worse. Now there is a video file missing, and the counts are still off. About at a loss for now.

Working on adding a counter for errors. If it doesn't work this time, calling it a night. Error count code worked, gave me some clues as to what is happeneing.

        except:
            VideoCodecCounts['error'] += 1
            rename(current, current[0:-4] + '[ERROR]' + current[-4:])
            TotalCount += 1
            output_box.insert('1.0', 'New name: ' + newName)
            output_box.insert(1.0, "\n")
The files are getting renamed, but the TotalCount is not being incremented. This tells me there is likely something wrong with the TotalCount += 1 statement. I still can't get this working, calling it a night. Just removing the incorrect counts from the output. This should at least stop people from gettng really confused. Adding up the error codec counts and the valid video codec counts does equal the proper total. 

Finally got the total count properly displayed using the following:
TotalCount = VideoCount + VideoCodecCounts['error']
Added that into the proper output statement and verified works. 

End of notes.